### PR TITLE
feat: ダークテーマからライトモダンテーマにデザイン全面リニューアル

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,20 +1,29 @@
 :root {
-  /* Premium Dark Theme Colors */
-  --bg-dark: #05050a;
-  --bg-surface: rgba(255, 255, 255, 0.03);
-  --bg-surface-hover: rgba(255, 255, 255, 0.06);
-  --border-color: rgba(255, 255, 255, 0.08);
+  /* Light Modern Theme */
+  --bg-main: #f8f9fc;
+  --bg-white: #ffffff;
+  --bg-subtle: #f0f2f8;
+  --bg-hero: linear-gradient(135deg, #eef2ff 0%, #f8f9fc 40%, #fdf2f8 100%);
+  --border-color: rgba(0, 0, 0, 0.06);
+  --border-color-strong: rgba(0, 0, 0, 0.10);
 
-  --text-main: #ffffff;
-  --text-muted: #a1a1aa;
+  --text-main: #111827;
+  --text-secondary: #374151;
+  --text-muted: #6b7280;
 
-  --accent-cyan: #06b6d4;
+  --accent-indigo: #4f46e5;
+  --accent-violet: #7c3aed;
   --accent-blue: #3b82f6;
-  --accent-purple: #8b5cf6;
-  --accent-magenta: #d946ef;
+  --accent-cyan: #0ea5e9;
+  --accent-pink: #ec4899;
 
   --color-success: #10b981;
   --color-danger: #ef4444;
+
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.06);
+  --shadow-md: 0 4px 16px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04);
+  --shadow-lg: 0 10px 40px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04);
+  --shadow-xl: 0 20px 60px rgba(0,0,0,0.10);
 
   /* Typography */
   --font-sans: 'Inter', 'Noto Sans JP', sans-serif;
@@ -40,55 +49,17 @@ html {
 
 body {
   font-family: var(--font-sans);
-  background-color: var(--bg-dark);
+  background-color: var(--bg-main);
   color: var(--text-main);
-  line-height: 1.6;
+  line-height: 1.7;
   -webkit-font-smoothing: antialiased;
   position: relative;
   overflow-x: hidden;
 }
 
-/* Background Ambient Glows */
-body::before,
-body::after {
-  content: "";
-  position: fixed;
-  border-radius: 50%;
-  filter: blur(150px);
-  z-index: -1;
-  opacity: 0.15;
-  pointer-events: none;
-}
-
-body::before {
-  top: -10%;
-  left: -10%;
-  width: 50vw;
-  height: 50vh;
-  background: var(--accent-blue);
-  animation: float-glow 20s ease-in-out infinite alternate;
-}
-
-body::after {
-  bottom: -10%;
-  right: -10%;
-  width: 60vw;
-  height: 60vh;
-  background: var(--accent-purple);
-  animation: float-glow 25s ease-in-out infinite alternate-reverse;
-}
-
-@keyframes float-glow {
-  0% {
-    transform: translate(0, 0) scale(1);
-  }
-
-  100% {
-    transform: translate(5%, 5%) scale(1.1);
-  }
-}
-
-/* Header Navigation */
+/* ===================================
+   Header Navigation
+   =================================== */
 .site-header {
   position: fixed;
   top: 0;
@@ -98,7 +69,8 @@ body::after {
   padding: 0 24px;
   transform: translateY(-100%);
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-              background 0.3s ease;
+              background 0.3s ease,
+              box-shadow 0.3s ease;
 }
 
 .site-header.visible {
@@ -106,9 +78,10 @@ body::after {
 }
 
 .site-header.scrolled {
-  background: rgba(5, 5, 10, 0.8);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
   border-bottom: 1px solid var(--border-color);
 }
 
@@ -117,17 +90,16 @@ body::after {
   align-items: center;
   justify-content: space-between;
   height: 64px;
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
 .header-logo {
   font-family: var(--font-display);
-  font-size: 1.25rem;
+  font-size: 1.3rem;
   font-weight: 800;
-  letter-spacing: 0.05em;
-  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  letter-spacing: 0.04em;
+  color: var(--accent-indigo);
 }
 
 .header-nav {
@@ -148,16 +120,18 @@ body::after {
 }
 
 .nav-cta {
-  background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+  background: var(--accent-indigo);
   color: #fff !important;
-  padding: 8px 20px;
+  padding: 8px 22px;
   border-radius: 9999px;
   font-weight: 600;
   font-size: 0.85rem;
+  transition: var(--transition-base);
 }
 
 .nav-cta:hover {
-  box-shadow: 0 4px 20px rgba(139, 92, 246, 0.4);
+  background: var(--accent-violet);
+  box-shadow: 0 4px 16px rgba(79, 70, 229, 0.3);
   transform: translateY(-1px);
 }
 
@@ -205,13 +179,14 @@ body::after {
     top: 64px;
     left: 0;
     right: 0;
-    background: rgba(5, 5, 10, 0.95);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    background: rgba(255, 255, 255, 0.97);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
     flex-direction: column;
     padding: 24px;
     gap: 0;
     border-bottom: 1px solid var(--border-color);
+    box-shadow: var(--shadow-lg);
     transform: translateY(-100%);
     opacity: 0;
     pointer-events: none;
@@ -244,20 +219,18 @@ body::after {
   }
 }
 
-/* Typography & Utilities */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+/* ===================================
+   Typography & Utilities
+   =================================== */
+h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-display);
   font-weight: 700;
-  line-height: 1.2;
+  line-height: 1.25;
+  color: var(--text-main);
 }
 
 .text-gradient {
-  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue), var(--accent-purple));
+  background: linear-gradient(135deg, var(--accent-indigo), var(--accent-violet));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -269,25 +242,11 @@ a {
   transition: var(--transition-base);
 }
 
-.opacity-80 {
-  opacity: 0.8;
-}
-
-.mt-2 {
-  margin-top: 8px;
-}
-
-.mt-4 {
-  margin-top: 24px;
-}
-
-.mt-5 {
-  margin-top: 48px;
-}
-
-.mb-2 {
-  margin-bottom: 8px;
-}
+.opacity-80 { opacity: 0.85; }
+.mt-2 { margin-top: 8px; }
+.mt-4 { margin-top: 24px; }
+.mt-5 { margin-top: 48px; }
+.mb-2 { margin-bottom: 8px; }
 
 .container {
   width: 100%;
@@ -296,33 +255,35 @@ a {
   padding: 0 24px;
 }
 
-.text-center {
-  text-align: center;
-}
+.text-center { text-align: center; }
+.text-left { text-align: left; }
 
 section {
   padding: var(--section-padding) 0;
 }
 
-/* Buttons */
+/* ===================================
+   Buttons
+   =================================== */
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-family: var(--font-sans);
   font-weight: 600;
-  padding: 14px 28px;
-  border-radius: 9999px;
+  padding: 14px 32px;
+  border-radius: 12px;
   transition: var(--transition-base);
   cursor: pointer;
   border: none;
   letter-spacing: 0.02em;
+  font-size: 1rem;
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+  background: var(--accent-indigo);
   color: #fff;
-  box-shadow: 0 4px 20px rgba(139, 92, 246, 0.3);
+  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.25);
   position: relative;
   overflow: hidden;
 }
@@ -334,7 +295,7 @@ section {
   left: 0;
   right: 0;
   bottom: 0;
-  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
+  background: linear-gradient(135deg, var(--accent-indigo), var(--accent-violet));
   opacity: 0;
   transition: var(--transition-base);
 }
@@ -345,7 +306,7 @@ section {
 
 .btn-primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 30px rgba(139, 92, 246, 0.5);
+  box-shadow: 0 8px 25px rgba(79, 70, 229, 0.35);
 }
 
 .btn-primary span,
@@ -357,33 +318,36 @@ section {
 .btn-large {
   font-size: 1.125rem;
   padding: 18px 48px;
+  border-radius: 14px;
 }
 
-/* Glassmorphism */
+/* ===================================
+   Cards
+   =================================== */
 .glass-panel {
-  background: var(--bg-surface);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: 24px;
+  border-radius: 20px;
+  box-shadow: var(--shadow-sm);
   transition: var(--transition-base);
 }
 
 .glass-panel:hover {
-  background: var(--bg-surface-hover);
-  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: var(--shadow-md);
+  border-color: var(--border-color-strong);
 }
 
 .glass-container {
-  background: var(--bg-surface);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: var(--bg-white);
   border: 1px solid var(--border-color);
-  border-radius: 32px;
+  border-radius: 24px;
   padding: 64px 48px;
+  box-shadow: var(--shadow-md);
 }
 
-/* Section Headers */
+/* ===================================
+   Section Headers
+   =================================== */
 .section-header {
   margin-bottom: 64px;
 }
@@ -391,12 +355,15 @@ section {
 .section-label {
   display: inline-block;
   font-family: var(--font-sans);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.15em;
-  color: var(--accent-cyan);
+  color: var(--accent-indigo);
   margin-bottom: 16px;
   text-transform: uppercase;
+  background: rgba(79, 70, 229, 0.08);
+  padding: 6px 14px;
+  border-radius: 9999px;
 }
 
 .section-label.align-center {
@@ -409,6 +376,7 @@ section {
 .section-title {
   font-size: 2.5rem;
   margin-bottom: 24px;
+  color: var(--text-main);
 }
 
 .section-lead {
@@ -418,7 +386,9 @@ section {
   margin: 0 auto;
 }
 
-/* Animations */
+/* ===================================
+   Animations
+   =================================== */
 .reveal {
   opacity: 0;
   transform: translateY(40px);
@@ -430,7 +400,9 @@ section {
   transform: translateY(0);
 }
 
-/* Hero Section */
+/* ===================================
+   Hero Section
+   =================================== */
 .hero {
   min-height: 100vh;
   display: flex;
@@ -439,6 +411,36 @@ section {
   padding-top: 80px;
   text-align: center;
   position: relative;
+  background: var(--bg-hero);
+  overflow: hidden;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  top: -30%;
+  right: -20%;
+  width: 600px;
+  height: 600px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(79, 70, 229, 0.08), transparent 70%);
+  pointer-events: none;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  bottom: -20%;
+  left: -15%;
+  width: 500px;
+  height: 500px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(236, 72, 153, 0.06), transparent 70%);
+  pointer-events: none;
+}
+
+.hero-bg-overlay {
+  display: none;
 }
 
 .hero-content {
@@ -448,35 +450,57 @@ section {
 }
 
 .hero-title {
-  font-size: clamp(3rem, 6vw, 5rem);
-  letter-spacing: -0.02em;
-  margin-bottom: 32px;
+  font-size: clamp(3rem, 6vw, 4.5rem);
+  letter-spacing: -0.03em;
+  margin-bottom: 28px;
+  color: var(--text-main);
+  font-weight: 800;
 }
 
 .hero-subtitle {
-  font-size: clamp(1.125rem, 2vw, 1.25rem);
+  font-size: clamp(1rem, 2vw, 1.2rem);
   color: var(--text-muted);
   margin-bottom: 48px;
+  line-height: 1.8;
 }
 
-/* Problem Section */
+.hero-cta .btn {
+  border-radius: 14px;
+  padding: 18px 40px;
+  font-size: 1.1rem;
+}
+
+/* ===================================
+   Problem Section
+   =================================== */
+.problem {
+  background: var(--bg-white);
+}
+
 .problem-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 32px;
+  gap: 24px;
 }
 
 .problem-card {
-  padding: 40px 32px;
+  padding: 36px 32px;
   position: relative;
   overflow: hidden;
+  background: var(--bg-main);
+  border: 1px solid var(--border-color);
+}
+
+.problem-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 
 .problem-num {
   font-family: var(--font-display);
-  font-size: 4rem;
+  font-size: 3.5rem;
   font-weight: 800;
-  color: rgba(255, 255, 255, 0.05);
+  color: rgba(79, 70, 229, 0.07);
   position: absolute;
   top: 10px;
   right: 20px;
@@ -484,17 +508,38 @@ section {
 }
 
 .problem-title {
-  font-size: 1.25rem;
-  margin-bottom: 16px;
-  color: #fff;
+  font-size: 1.2rem;
+  margin-bottom: 14px;
+  color: var(--text-main);
+  font-weight: 700;
 }
 
 .problem-desc {
   color: var(--text-muted);
   font-size: 0.95rem;
+  line-height: 1.7;
 }
 
-/* Solution Section */
+/* ===================================
+   Solution Section
+   =================================== */
+.solution {
+  background: var(--bg-main);
+}
+
+.solution-container {
+  background: var(--bg-white);
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border-color);
+}
+
+.solution-lead {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+  margin-top: 16px;
+  line-height: 1.8;
+}
+
 .solution-features {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -510,56 +555,58 @@ section {
 }
 
 .feature-icon {
-  width: 64px;
-  height: 64px;
-  border-radius: 20px;
+  width: 60px;
+  height: 60px;
+  border-radius: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   margin-bottom: 24px;
-  background: var(--bg-surface);
-  border: 1px solid var(--border-color);
 }
 
 .feature-icon.icon-cyan {
   color: var(--accent-cyan);
-  box-shadow: 0 0 30px rgba(6, 182, 212, 0.15);
+  background: rgba(14, 165, 233, 0.08);
 }
 
 .feature-icon.icon-purple {
-  color: var(--accent-purple);
-  box-shadow: 0 0 30px rgba(139, 92, 246, 0.15);
+  color: var(--accent-violet);
+  background: rgba(124, 58, 237, 0.08);
 }
 
 .feature-content h3 {
-  font-size: 1.25rem;
-  margin-bottom: 16px;
+  font-size: 1.2rem;
+  margin-bottom: 14px;
+  color: var(--text-main);
 }
 
 .feature-content p {
   color: var(--text-muted);
   font-size: 0.95rem;
+  line-height: 1.7;
 }
 
-/* Difference Section */
+/* ===================================
+   Difference Section
+   =================================== */
 .difference {
   position: relative;
   overflow: hidden;
+  background: var(--bg-white);
 }
 
 .difference::before {
   content: '';
   position: absolute;
   top: 0;
-  left: 0;
-  width: 100%;
+  right: 0;
+  width: 40%;
   height: 100%;
-  background: url('../assets/difference-bg.png') center / cover no-repeat;
-  opacity: 0.15;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.03), rgba(236, 72, 153, 0.03));
   z-index: 0;
 }
 
-.difference>.container {
+.difference > .container {
   position: relative;
   z-index: 1;
 }
@@ -568,22 +615,30 @@ section {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 64px;
-  align-items: center;
+  align-items: start;
 }
 
 .highlight-title {
-  font-size: 1.75rem;
-  color: var(--accent-cyan);
+  font-size: 1.6rem;
+  color: var(--accent-indigo);
+}
+
+.difference-content p {
+  color: var(--text-secondary);
+  line-height: 1.8;
 }
 
 .strong-points {
   padding: 32px;
-  background: linear-gradient(135deg, rgba(6, 182, 212, 0.05), rgba(139, 92, 246, 0.05));
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.04), rgba(124, 58, 237, 0.04));
+  border: 1px solid rgba(79, 70, 229, 0.1);
 }
 
 .points-lead {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   margin-bottom: 20px;
+  color: var(--text-main);
+  line-height: 1.7;
 }
 
 .check-list {
@@ -595,7 +650,8 @@ section {
   position: relative;
   padding-left: 32px;
   margin-bottom: 12px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
+  line-height: 1.7;
 }
 
 .check-list li::before {
@@ -606,22 +662,30 @@ section {
   font-weight: bold;
 }
 
+.points-conclusion {
+  color: var(--text-secondary);
+}
+
+/* Profile Card */
 .profile-card {
-  padding: 40px;
+  padding: 36px;
+  background: var(--bg-white);
+  position: sticky;
+  top: 100px;
 }
 
 .profile-header {
   display: flex;
   align-items: center;
-  gap: 24px;
+  gap: 20px;
   margin-bottom: 24px;
 }
 
 .profile-avatar {
-  width: 80px;
-  height: 80px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-blue), var(--accent-purple));
+  background: linear-gradient(135deg, var(--accent-indigo), var(--accent-violet));
   padding: 3px;
   flex-shrink: 0;
 }
@@ -634,107 +698,83 @@ section {
   display: block;
 }
 
-.avatar-shapes {
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  background: var(--bg-dark);
-  position: relative;
-  overflow: hidden;
-}
-
-.avatar-shapes .s1 {
-  position: absolute;
-  top: -20%;
-  right: -20%;
-  width: 100%;
-  height: 100%;
-  background: var(--accent-cyan);
-  border-radius: 50%;
-  filter: blur(20px);
-  opacity: 0.5;
-}
-
-.avatar-shapes .s2 {
-  position: absolute;
-  bottom: -20%;
-  left: -20%;
-  width: 100%;
-  height: 100%;
-  background: var(--accent-magenta);
-  border-radius: 50%;
-  filter: blur(20px);
-  opacity: 0.5;
-}
-
 .profile-role {
-  font-size: 0.85rem;
-  color: var(--accent-cyan);
+  font-size: 0.8rem;
+  color: var(--accent-indigo);
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .profile-name {
-  font-size: 1.5rem;
+  font-size: 1.35rem;
   margin-top: 4px;
 }
 
 .profile-name-en {
-  font-size: 1rem;
+  font-size: 0.9rem;
   color: var(--text-muted);
   font-weight: 400;
 }
 
 .profile-desc {
   color: var(--text-muted);
-  font-size: 0.95rem;
+  font-size: 0.93rem;
+  line-height: 1.8;
 }
 
 .profile-desc p {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .profile-desc p:last-child {
   margin-bottom: 0;
 }
 
-/* Examples Section - Chat UI */
+/* ===================================
+   Examples Section - Chat UI
+   =================================== */
+.examples {
+  background: var(--bg-main);
+}
+
 .chat-container {
   max-width: 800px;
   margin: 48px auto 0;
-  padding: 48px;
-  background: linear-gradient(to bottom right, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.05));
+  padding: 40px;
+  background: var(--bg-white);
 }
 
 .chat-messages {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 .chat-bubble {
-  max-width: 80%;
-  padding: 16px 24px;
-  border-radius: 20px;
-  font-size: 1rem;
-  line-height: 1.5;
+  max-width: 85%;
+  padding: 14px 22px;
+  border-radius: 18px;
+  font-size: 0.95rem;
+  line-height: 1.6;
   position: relative;
 }
 
 .chat-bubble.user-msg {
-  background: var(--bg-surface-hover);
+  background: var(--bg-subtle);
   border: 1px solid var(--border-color);
   border-bottom-left-radius: 4px;
   align-self: flex-start;
+  color: var(--text-secondary);
 }
 
 .chat-bubble.right {
   align-self: flex-end;
-  border-radius: 20px;
+  border-radius: 18px;
   border-bottom-right-radius: 4px;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(139, 92, 246, 0.2));
-  border-color: rgba(139, 92, 246, 0.3);
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.08), rgba(124, 58, 237, 0.08));
+  border: 1px solid rgba(79, 70, 229, 0.12);
+  color: var(--text-secondary);
 }
 
 .animate-up {
@@ -753,17 +793,30 @@ section {
   }
 }
 
-/* How It Works Section */
+/* ===================================
+   How It Works Section
+   =================================== */
+.how-it-works {
+  background: var(--bg-white);
+}
+
 .steps-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 24px;
+  gap: 20px;
   margin-top: 48px;
 }
 
 .step-card {
   padding: 32px 24px;
   text-align: center;
+  background: var(--bg-main);
+  border: 1px solid var(--border-color);
+}
+
+.step-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 
 .step-num {
@@ -774,17 +827,20 @@ section {
 }
 
 .step-title {
-  font-size: 1.125rem;
-  margin-bottom: 12px;
+  font-size: 1.1rem;
+  margin-bottom: 10px;
+  color: var(--text-main);
 }
 
 .step-desc {
   font-size: 0.9rem;
   color: var(--text-muted);
+  line-height: 1.6;
 }
 
 .service-details {
   padding: 48px;
+  background: var(--bg-white);
 }
 
 .service-details-title {
@@ -800,33 +856,41 @@ section {
 }
 
 .dot {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
-  background: var(--accent-cyan);
-  box-shadow: 0 0 10px var(--accent-cyan);
+  background: var(--accent-indigo);
   display: inline-block;
 }
 
 .service-detail-item h4 {
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   margin-bottom: 8px;
+  color: var(--text-main);
 }
 
 .service-detail-item p {
   font-size: 0.9rem;
   color: var(--text-muted);
+  line-height: 1.7;
 }
 
-/* Scope Section */
+/* ===================================
+   Scope Section
+   =================================== */
+.scope {
+  background: var(--bg-main);
+}
+
 .scope-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 32px;
+  gap: 24px;
 }
 
 .scope-card {
   padding: 40px;
+  background: var(--bg-white);
 }
 
 .scope-header {
@@ -837,8 +901,8 @@ section {
 }
 
 .scope-icon {
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
   border-radius: 12px;
   display: flex;
   align-items: center;
@@ -854,7 +918,7 @@ section {
 }
 
 .scope-header h3 {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
 }
 
 .scope-list {
@@ -864,7 +928,8 @@ section {
 .scope-list li {
   padding: 12px 0;
   border-bottom: 1px solid var(--border-color);
-  color: var(--text-muted);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
 }
 
 .scope-list li:last-child {
@@ -874,14 +939,21 @@ section {
 .scope-notes {
   margin-top: 24px;
   font-size: 0.85rem;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
 }
 
-/* FAQ Section */
+/* ===================================
+   FAQ Section
+   =================================== */
+.faq {
+  background: var(--bg-white);
+}
+
 .faq-accordion {
   max-width: 800px;
   margin: 0 auto;
-  padding: 16px;
+  padding: 8px;
+  background: var(--bg-white);
 }
 
 .faq-item {
@@ -902,20 +974,22 @@ section {
   align-items: center;
   color: var(--text-main);
   font-family: var(--font-sans);
-  font-size: 1.125rem;
+  font-size: 1.05rem;
   font-weight: 600;
   cursor: pointer;
   text-align: left;
+  transition: color 0.2s ease;
 }
 
 .faq-question:hover {
-  color: var(--accent-cyan);
+  color: var(--accent-indigo);
 }
 
 .faq-question .icon {
   width: 24px;
   height: 24px;
   position: relative;
+  flex-shrink: 0;
 }
 
 .faq-question .icon::before,
@@ -946,7 +1020,7 @@ section {
 }
 
 .faq-item.active .faq-question {
-  color: var(--accent-blue);
+  color: var(--accent-indigo);
 }
 
 .faq-answer {
@@ -958,43 +1032,37 @@ section {
 .faq-answer p {
   padding: 0 16px 24px;
   color: var(--text-muted);
+  line-height: 1.8;
 }
 
-/* CTA Section */
+/* ===================================
+   CTA Section
+   =================================== */
 .cta {
-  padding: 160px 0;
+  padding: 140px 0;
   position: relative;
-}
-
-.cta::before {
-  content: "";
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 100%;
-  height: 100%;
-  background: radial-gradient(circle at center, rgba(139, 92, 246, 0.1) 0%, transparent 70%);
-  pointer-events: none;
-  z-index: -1;
+  background: linear-gradient(180deg, var(--bg-main) 0%, #eef2ff 50%, var(--bg-main) 100%);
 }
 
 .cta-title {
-  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
   margin-bottom: 48px;
+  color: var(--text-main);
 }
 
+/* Price Box */
 .price-box {
-  max-width: 600px;
+  max-width: 520px;
   margin: 0 auto 48px;
-  padding: 48px;
+  padding: 48px 40px;
   position: relative;
+  background: var(--bg-white);
+  border-radius: 24px;
 }
 
 .has-campaign {
-  border: 2px solid var(--accent-magenta);
-  background: linear-gradient(to bottom, rgba(217, 70, 239, 0.05), rgba(5, 5, 10, 0.95));
-  box-shadow: 0 0 40px rgba(217, 70, 239, 0.15);
+  border: 2px solid var(--accent-pink);
+  box-shadow: 0 8px 40px rgba(236, 72, 153, 0.12);
 }
 
 .campaign-header {
@@ -1006,19 +1074,19 @@ section {
 }
 
 .campaign-tag {
-  background: linear-gradient(135deg, var(--accent-magenta), var(--color-danger));
+  background: linear-gradient(135deg, var(--accent-pink), #f43f5e);
   color: white;
   padding: 8px 24px;
   border-radius: 999px;
   font-weight: 800;
-  letter-spacing: 0.1em;
-  font-size: 1.1rem;
-  box-shadow: 0 4px 15px rgba(217, 70, 239, 0.4);
+  letter-spacing: 0.05em;
+  font-size: 1rem;
+  box-shadow: 0 4px 15px rgba(236, 72, 153, 0.3);
 }
 
 .price-original {
   margin-top: 16px;
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   color: var(--text-muted);
   display: flex;
   align-items: center;
@@ -1030,11 +1098,11 @@ section {
 .strikethrough {
   text-decoration: line-through;
   text-decoration-color: var(--color-danger);
-  text-decoration-thickness: 3px;
+  text-decoration-thickness: 2px;
 }
 
 .price-period {
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 400;
 }
 
@@ -1045,111 +1113,52 @@ section {
 }
 
 .campaign-discount {
-  font-size: 2rem;
+  font-size: 1.8rem;
   font-family: var(--font-display);
   font-weight: 900;
   line-height: 1;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .campaign-amount {
-  font-size: 4.5rem;
+  font-size: 4rem;
   font-family: var(--font-display);
   font-weight: 900;
   line-height: 1;
-  color: white;
-  margin-bottom: 16px;
-  text-shadow: 0 0 20px rgba(217, 70, 239, 0.3);
+  color: var(--text-main);
+  margin-bottom: 12px;
 }
 
 .campaign-period {
-  font-size: 1.5rem;
+  font-size: 1.3rem;
   font-family: var(--font-sans);
   color: var(--text-muted);
   font-weight: 600;
-  margin-left: 8px;
+  margin-left: 6px;
 }
 
 .campaign-sub {
-  font-size: 1.125rem;
-  color: #fff;
+  font-size: 1rem;
+  color: var(--text-secondary);
   font-weight: 600;
 }
 
 .cta-sub {
-  font-size: 1.125rem;
+  font-size: 1.1rem;
   color: var(--text-muted);
   margin-bottom: 40px;
+  line-height: 1.8;
 }
 
-.cta-contact-note {
-  margin-top: 16px;
-  font-size: 0.9rem;
-  color: var(--text-muted);
-}
-
-/* Footer */
-.footer {
-  border-top: 1px solid var(--border-color);
-  padding: 48px 0;
-}
-
-.footer-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-bottom: 24px;
-}
-
-.footer-content p {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-bottom: 8px;
-}
-
-.footer-link {
-  font-family: var(--font-display);
-  font-size: 1.25rem;
-  font-weight: 700;
-  color: #fff;
-}
-
-.footer-link:hover {
-  color: var(--accent-cyan);
-}
-
-.footer-bottom {
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-/* Responsive */
-@media (max-width: 992px) {
-  .difference-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .profile-card {
-    margin-top: 32px;
-  }
-
-  .glass-container {
-    padding: 40px 24px;
-  }
-}
-
-.chat-bubble {
-  max-width: 90%;
-}
-
-/* Form Styles */
+/* ===================================
+   Contact Form
+   =================================== */
 .inline-form-container {
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+  background: var(--bg-white);
+  box-shadow: var(--shadow-lg);
 }
 
 .modal-header {
@@ -1158,13 +1167,14 @@ section {
 }
 
 .modal-header h3 {
-  font-size: 1.75rem;
+  font-size: 1.6rem;
   margin-bottom: 12px;
 }
 
 .modal-header p {
   color: var(--text-muted);
   font-size: 0.95rem;
+  line-height: 1.7;
 }
 
 .form-group {
@@ -1175,13 +1185,14 @@ section {
   display: block;
   font-weight: 600;
   margin-bottom: 8px;
-  font-size: 0.95rem;
+  font-size: 0.93rem;
+  color: var(--text-main);
 }
 
 .required {
-  background: rgba(239, 68, 68, 0.15);
+  background: rgba(239, 68, 68, 0.08);
   color: var(--color-danger);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   padding: 2px 8px;
   border-radius: 4px;
   margin-left: 8px;
@@ -1193,10 +1204,10 @@ input[type="text"],
 input[type="email"],
 textarea {
   width: 100%;
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
+  padding: 14px 16px;
+  background: var(--bg-main);
+  border: 1px solid var(--border-color-strong);
+  border-radius: 10px;
   color: var(--text-main);
   font-family: var(--font-sans);
   font-size: 1rem;
@@ -1206,14 +1217,14 @@ textarea {
 input:focus,
 textarea:focus {
   outline: none;
-  border-color: var(--accent-blue);
-  background: rgba(255, 255, 255, 0.08);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  border-color: var(--accent-indigo);
+  background: var(--bg-white);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
 }
 
 input::placeholder,
 textarea::placeholder {
-  color: rgba(255, 255, 255, 0.3);
+  color: #9ca3af;
 }
 
 textarea {
@@ -1236,21 +1247,21 @@ textarea {
 }
 
 .success-icon {
-  width: 64px;
-  height: 64px;
+  width: 60px;
+  height: 60px;
   background: var(--color-success);
   color: #fff;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
+  font-size: 1.8rem;
   margin: 0 auto 24px;
-  box-shadow: 0 0 30px rgba(16, 185, 129, 0.3);
+  box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);
 }
 
 .form-success-message h4 {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   margin-bottom: 16px;
 }
 
@@ -1263,15 +1274,112 @@ textarea {
     opacity: 0;
     transform: translateY(10px);
   }
-
   to {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
+/* ===================================
+   Footer
+   =================================== */
+.footer {
+  border-top: 1px solid var(--border-color);
+  padding: 48px 0;
+  background: var(--bg-white);
+}
+
+.footer-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.footer-content p {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: 8px;
+}
+
+.footer-link {
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.footer-link:hover {
+  color: var(--accent-indigo);
+}
+
+.footer-links {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.footer-links a {
+  color: var(--text-muted) !important;
+  font-size: 0.85rem !important;
+  text-decoration: underline !important;
+}
+
+.footer-bottom {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+/* ===================================
+   Responsive
+   =================================== */
+@media (max-width: 992px) {
+  .difference-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-card {
+    margin-top: 32px;
+    position: static;
+  }
+
+  .glass-container {
+    padding: 40px 24px;
+  }
+
+  .section-title {
+    font-size: 2rem;
+  }
+}
+
 @media (max-width: 600px) {
-  .modal-content {
+  :root {
+    --section-padding: 80px;
+  }
+
+  .hero-title {
+    font-size: 2.5rem;
+  }
+
+  .section-title {
+    font-size: 1.75rem;
+  }
+
+  .price-box {
+    padding: 40px 24px;
+  }
+
+  .campaign-amount {
+    font-size: 3rem;
+  }
+
+  .service-details {
     padding: 32px 24px;
+  }
+
+  .scope-card {
+    padding: 28px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 
-<body class="dark-theme">
+<body>
 
     <!-- Header Navigation -->
     <header class="site-header" id="site-header">


### PR DESCRIPTION
- 背景を真っ黒(#05050a)から明るいグレーホワイト(#f8f9fc)に変更
- ガラスモーフィズムパネルをクリーンな白カード+ソフトシャドウに置換
- ネオングロウをインディゴ/バイオレットの落ち着いたアクセントに変更
- セクション背景を白/グレー交互にしてリズムを改善
- ボタンの角丸をモダンな12-14pxに調整
- ヒーローセクションに淡いグラデーション背景を追加
- bodyからdark-themeクラスを削除